### PR TITLE
Pin provider-gcp-storage to v1

### DIFF
--- a/template/upbound.yaml
+++ b/template/upbound.yaml
@@ -11,11 +11,11 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Function
     package: xpkg.upbound.io/crossplane-contrib/function-auto-ready
-    version: '>=v0.0.0'
+    version: 'v0.5.0'
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-gcp-storage
-    version: '>=v0.0.0'
+    version: '^v1.14.1'
   description: This is where you can describe your project.
   license: Apache-2.0
   maintainer: Upbound User <user@example.com>


### PR DESCRIPTION
### Description of your changes

The official v2 providers don't work in Crossplane v1, since they require a UXP license. Pin our provider dependency to v1 for now so that this template works in v1 clusters.

While we're here, pin function-auto-ready to v0.5.0, to avoid any unexpected behavior in the future.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

CI!
