### PR TITLE
Add go-templating tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         language: [go, go-templating, kcl, python]
-        test-language: [kcl, python]
+        test-language: [go-templating, kcl, python]
     env:
       UP_ORG: ${{ secrets.UP_ORG }}
       UP_API_TOKEN: ${{ secrets.UP_API_TOKEN }}
@@ -72,6 +72,11 @@ jobs:
 
       - name: Build project
         run: cd generated-project && up project build
+
+      - name: Run composition tests
+        run: |
+          cd generated-project
+          up test run tests/* --local --skip-control-plane-cleanup
 
       - name: Run e2e tests
         env:

--- a/template/tests/e2etest-xstoragebucket-go-templating/test.yaml.gotmpl
+++ b/template/tests/e2etest-xstoragebucket-go-templating/test.yaml.gotmpl
@@ -1,0 +1,51 @@
+# code: language=yaml
+# yaml-language-server: $schema=../../.up/json/models/test.schema.json
+
+{{- $gcp_project_id := env "UP_GCP_PROJECT_ID" }}
+{{- $gcp_creds := (env "UP_GCP_CREDS") | b64enc }}
+
+items:
+- apiVersion: meta.dev.upbound.io/v1alpha1
+  kind: E2ETest
+  metadata:
+    name: e2etest-xstoragebucket
+  spec:
+    cleanupTimeoutSeconds: 600
+    crossplane:
+      autoUpgrade:
+        channel: Rapid
+      state: Running
+    defaultConditions:
+      - Ready
+    extraResources:
+      - apiVersion: gcp.upbound.io/v1beta1
+        kind: ProviderConfig
+        metadata:
+          name: default
+        spec:
+          credentials:
+            secretRef:
+              key: credentials
+              name: gcp-credentials
+              namespace: crossplane-system
+            source: Secret
+          projectID: {{ print $gcp_project_id }}
+      - apiVersion: v1
+        data:
+          credentials: {{ print $gcp_creds }}
+        kind: Secret
+        metadata:
+          name: gcp-credentials
+          namespace: crossplane-system
+    manifests:
+      - apiVersion: platform.example.com/v1alpha1
+        kind: XStorageBucket
+        metadata:
+          name: uptest-bucket-xr-kcl
+        spec:
+          parameters:
+            acl: private
+            location: EU
+            versioning: true
+    skipDelete: false
+    timeoutSeconds: 300

--- a/template/tests/test-xstoragebucket-go-templating/01-resources.yaml.gotmpl
+++ b/template/tests/test-xstoragebucket-go-templating/01-resources.yaml.gotmpl
@@ -1,0 +1,68 @@
+# code: language=yaml
+# yaml-language-server: $schema=../../.up/json/models/test.schema.json
+
+{{- $expectedXR := `
+- apiVersion: platform.example.com/v1alpha1
+  kind: XStorageBucket
+  metadata:
+    name: example
+  spec:
+    parameters:
+      acl: publicRead
+      location: US
+      versioning: true
+`}}
+
+{{- $expectedBucketBefore := `
+- apiVersion: storage.gcp.upbound.io/v1beta1
+  kind: Bucket
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: bucket
+  spec:
+    forProvider:
+      location: US
+      versioning:
+      - enabled: true
+`}}
+
+{{- $observedBucket := `
+- apiVersion: storage.gcp.upbound.io/v1beta1
+  kind: Bucket
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: bucket
+      crossplane.io/external-name: example-bucket
+    name: example-bucket
+  spec:
+    forProvider:
+      location: US
+      versioning:
+      - enabled: true
+`}}
+
+{{- $expectedBucketAfter := `
+- apiVersion: storage.gcp.upbound.io/v1beta1
+  kind: Bucket
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: bucket
+    name: example-bucket
+  spec:
+    forProvider:
+      location: US
+      versioning:
+      - enabled: true
+`}}
+
+{{- $expectedACL := `
+- apiVersion: storage.gcp.upbound.io/v1beta1
+  kind: BucketACL
+  metadata:
+    annotations:
+      crossplane.io/composition-resource-name: acl
+  spec:
+    forProvider:
+      bucket: example-bucket
+      predefinedAcl: publicRead
+`}}

--- a/template/tests/test-xstoragebucket-go-templating/02-test.yaml.gotmpl
+++ b/template/tests/test-xstoragebucket-go-templating/02-test.yaml.gotmpl
@@ -1,0 +1,49 @@
+# code: language=yaml
+# yaml-language-server: $schema=../../.up/json/models/test.schema.json
+
+# This test suite validates the creation of resources for the XStorageBucket XR.
+# 
+# Creation of resources happens in two sequential calls to the composition
+# function:
+#
+# 1. The first time the function is called, the bucket has not yet been
+#    created. The ACL resource depends on the bucket's name, so the function
+#    creates only the bucket.
+# 
+# 2. When the function is called again after the bucket has been created, its
+#    name is available, so the ACL can also be created.
+#
+# The test suite contains two tests, one for each of the sequential calls. The
+# second test includes the bucket in its observed resources, triggering creation
+# of the dependent resources.
+
+items:
+- apiVersion: meta.dev.upbound.io/v1alpha1
+  kind: CompositionTest
+  metadata:
+    name: "test-xstoragebucket-bucket-not-yet-created"
+  spec:
+    assertResources:
+      {{- print $expectedXR | indent 6 }}
+      {{- print $expectedBucketBefore | indent 6 }}
+    compositionPath: "apis/xstoragebuckets/composition.yaml"
+    xrPath: "examples/xstoragebuckets/example.yaml"
+    xrdPath: "apis/xstoragebuckets/definition.yaml"
+    timeoutSeconds: 120
+    validate: false
+- apiVersion: meta.dev.upbound.io/v1alpha1
+  kind: CompositionTest
+  metadata:
+    name: "tests-xstoragebucket-bucket-created"
+  spec:
+    observedResources:
+      {{- print $observedBucket | indent 6 }}
+    assertResources:
+      {{- print $expectedXR | indent 6 }}
+      {{- print $expectedBucketAfter | indent 6 }}
+      {{- print $expectedACL | indent 6 }}
+    compositionPath: "apis/xstoragebuckets/composition.yaml"
+    xrPath: "examples/xstoragebuckets/example.yaml"
+    xrdPath: "apis/xstoragebuckets/definition.yaml"
+    timeoutSeconds: 120
+    validate: false


### PR DESCRIPTION
### Description of your changes

Add a go-templating implementation of the tests, matching the other implementations. Add go-templating to the test matrix in CI, and also add a step to run composition tests, since we weren't exercising them previously.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Composition tests tested locally; will rely on CI for e2e tests.
